### PR TITLE
Added support for macOS 11 and above

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ DerivedData/
 
 ## Various settings
 *.pbxuser
+.DS_Store
 !default.pbxuser
 *.mode1v3
 !default.mode1v3

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,5 +8,7 @@ large_tuple:
   warning: 6
 function_body_length:
   warning: 70
+line_length:
+  ignores_comments: true
 disabled_rules:
   - todo

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,11 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "SCNLine",
-    platforms: [.iOS(.v8)],
+    platforms: [.iOS(.v9), .macOS(.v11)], // Support for iOS 9 and macOS Big Sur.
     products: [
         .library(
             name: "SCNLine",

--- a/SCNLine.podspec
+++ b/SCNLine.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.name         = "SCNLine"
-  s.version      = "1.2.0"
+  s.version      = "1.3"
   s.summary      = "SCNLine lets you draw tubes."
   s.description  = <<-DESC
   					draw a thick line in SceneKit
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/maxxfrazer/SceneKit-SCNLine.git", :tag => "#{s.version}" }
   s.swift_version = '5.0'
   s.ios.deployment_target = '9.0'
+  s.osx.deployment_target = "11"
   # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   s.source_files  = "Sources/SCNLine/*.swift"
 end

--- a/Sources/SCNLine/SCNGeometry+Extensions.swift
+++ b/Sources/SCNLine/SCNGeometry+Extensions.swift
@@ -24,8 +24,8 @@ public struct GeometryParts {
 
 private extension simd_quatf {
   func act(_ vector: SCNVector3) -> SCNVector3 {
-    let vec = self.act(SIMD3<Float>([vector.x, vector.y, vector.z]))
-    return SCNVector3(vec.x, vec.y, vec.z)
+    let vec = self.act(SIMD3<Float>([vector.fx, vector.fy, vector.fz]))
+    return SCNVector3(UFloat(vec.x), UFloat(vec.y), UFloat(vec.z)) // Use UFloats
   }
   func split(by factor: Float = 2) -> simd_quatf {
     if self.angle == 0 {
@@ -39,7 +39,10 @@ private extension simd_quatf {
   }
 }
 private func rotationBetween2Vectors(start: SCNVector3, end: SCNVector3) -> simd_quatf {
-  return simd_quaternion(simd_float3([start.x, start.y, start.z]), simd_float3([end.x, end.y, end.z]))
+  return simd_quaternion(
+    simd_float3([start.fx, start.fy, start.fz]),
+    simd_float3([end.fx, end.fy, end.fz])
+  ) // Uses Float variables instead of the CGFloats on macOS.
 }
 public extension SCNGeometry {
 

--- a/Sources/SCNLine/SCNLineNode.swift
+++ b/Sources/SCNLine/SCNLineNode.swift
@@ -26,7 +26,12 @@ public class SCNLineNode: SCNNode {
       self.update()
     }
   }
-  public var lineMaterials = [SCNMaterial()]
+  public var lineMaterials = [SCNMaterial()] {
+    didSet {
+      // Only updating the materials, to avoid rebuilding the geometry.
+      self.geometry?.materials = lineMaterials
+    }
+  }
   public var maxTurning: Int {
     didSet {
       self.update()

--- a/Sources/SCNLine/SCNVector3+Extensions.swift
+++ b/Sources/SCNLine/SCNVector3+Extensions.swift
@@ -8,7 +8,21 @@
 
 import SceneKit
 
+// macOS uses CGFloats for describing SCNvector3.
+// In order to shae the same code, this typealias allows for conversion between Floats and CGFloats when needed
+#if os(macOS)
+typealias UFloat = CGFloat
+#elseif os(iOS)
+typealias UFloat = Float
+#endif
+
 internal extension SCNVector3 {
+
+  // Universal type for macOS and iOS allowing simultaneous compatiblity when doing operations.
+  // (Remember x, y and z are CGFloats on macOS)
+  var fx: Float {Float(x)}
+  var fy: Float {Float(y)}
+  var fz: Float {Float(z)}
 
   /**
    * Returns the length (magnitude) of the vector described by the SCNVector3
@@ -26,7 +40,7 @@ internal extension SCNVector3 {
    * Returns the squared length (magnitude) of the vector described by the SCNVector3
    */
   var lenSq: Float {
-    return x*x + y*y + z*z
+    return fx*fx + fy*fy + fz*fz
   }
 
   /**
@@ -48,14 +62,18 @@ internal extension SCNVector3 {
    * Calculates the dot product between two SCNVector3.
    */
   func dot(vector: SCNVector3) -> Float {
-    return x * vector.x + y * vector.y + z * vector.z
+    return fx * vector.fx + fy * vector.fy + fz * vector.fz
   }
 
   /**
    * Calculates the cross product between two SCNVector3.
    */
   func cross(vector: SCNVector3) -> SCNVector3 {
-    return SCNVector3(y * vector.z - z * vector.y, z * vector.x - x * vector.z, x * vector.y - y * vector.x)
+    return SCNVector3(
+      y * vector.z - z * vector.y,
+      z * vector.x - x * vector.z,
+      x * vector.y - y * vector.x
+    )
   }
 
   func flattened() -> SCNVector3 {
@@ -69,13 +87,13 @@ internal extension SCNVector3 {
   ///
   /// - returns: New SCNVector3 that has the rotation applied
   func rotate(about origin: SCNVector3, by: Float) -> SCNVector3 {
-    let pointRepositionedXY = [self.x - origin.x, self.z - origin.z]
+    let pointRepositionedXY = [self.fx - origin.fx, self.fz - origin.fz]
     let sinAngle = sin(by)
     let cosAngle = cos(by)
     return SCNVector3(
-      x: pointRepositionedXY[0] * cosAngle - pointRepositionedXY[1] * sinAngle + origin.x,
+      x: UFloat(pointRepositionedXY[0] * cosAngle - pointRepositionedXY[1] * sinAngle + origin.fx),
       y: self.y,
-      z: pointRepositionedXY[0] * sinAngle + pointRepositionedXY[1] * cosAngle + origin.z
+      z: UFloat(pointRepositionedXY[0] * sinAngle + pointRepositionedXY[1] * cosAngle + origin.fz)
     )
   }
 }
@@ -102,7 +120,7 @@ internal func - (left: SCNVector3, right: SCNVector3) -> SCNVector3 {
  * returns the result as a new SCNVector3.
  */
 internal func * (vector: SCNVector3, scalar: Float) -> SCNVector3 {
-  return SCNVector3Make(vector.x * scalar, vector.y * scalar, vector.z * scalar)
+  return SCNVector3Make(UFloat(vector.fx * scalar), UFloat(vector.fy * scalar), UFloat(vector.fz * scalar))
 }
 
 /**
@@ -124,5 +142,5 @@ internal func / (left: SCNVector3, right: SCNVector3) -> SCNVector3 {
  * returns the result as a new SCNVector3.
  */
 internal func / (vector: SCNVector3, scalar: Float) -> SCNVector3 {
-  return SCNVector3Make(vector.x / scalar, vector.y / scalar, vector.z / scalar)
+  return SCNVector3Make(UFloat(vector.fx / scalar), UFloat(vector.fy / scalar), UFloat(vector.fz / scalar))
 }


### PR DESCRIPTION
As SceneKit is both supported on macOS and iOS I decided to make this package multi-platform to use it with my project.

Code changes:
- Added UFloat typealias for conversion between CGFloats and Floats depending on the platform, as macOS uses CGFloats for defining SCNVectors
- Added fx, fy, fz Float computed variables to SCNVector3. Helps transforming x, y, z CGFloats on macOS to perform operations.

General changes:
- Package version 1.3
- Cocoa pods support for macOS 11
- Package swift manager support for macOS11
- swift-tools-version upgraded to 5.3